### PR TITLE
Can grab quantity units from a recipe

### DIFF
--- a/src/recipes.js
+++ b/src/recipes.js
@@ -8,6 +8,16 @@ export const findRecipeIngredients = (recipe) => {
   }, []);
 };
 
+export function findRecipeIngredientsQuantity(recipe) {
+  return recipe.ingredients.map((ingredient) => {
+    const amount = ingredient.quantity.amount;
+    const unit = ingredient.quantity.unit;
+    const space = unit.length ? " " : "";
+
+    return `${amount}${space}${unit}`;
+  });
+}
+
 export const findRecipeInstructions = (recipe) => {
   return recipe.instructions
     .sort((a, b) => a.number - b.number)

--- a/test/recipes-test.js
+++ b/test/recipes-test.js
@@ -1,6 +1,10 @@
 import { expect } from "chai";
 import { recipe1, recipe2 } from "../src/data/mockRecipe";
-import { findRecipeIngredients, findRecipeInstructions } from "../src/recipes";
+import {
+  findRecipeIngredients,
+  findRecipeIngredientsQuantity,
+  findRecipeInstructions,
+} from "../src/recipes";
 
 describe("Recipe", () => {
   describe("Find ingredients", () => {
@@ -35,6 +39,38 @@ describe("Recipe", () => {
         "sesame seeds",
         "sucrose",
         "unsalted butter",
+      ]);
+    });
+  });
+
+  describe("Find quantity of ingredients", () => {
+    it("Should return an array of ingredients quantities given a recipe", () => {
+      const ingredients = findRecipeIngredientsQuantity(recipe1);
+      expect(ingredients).to.deep.equal([
+        "1.5 c",
+        "0.5 tsp",
+        "1 large",
+        "0.5 c",
+        "3 Tbsp",
+        "0.5 c",
+        "0.5 tsp",
+        "24 servings",
+        "2 c",
+        "0.5 c",
+        "0.5 tsp",
+      ]);
+    });
+
+    it("Should return a different array of ingredients quantities given a different recipe", () => {
+      const ingredients = findRecipeIngredientsQuantity(recipe2);
+      expect(ingredients).to.deep.equal([
+        "160 g",
+        "40 g",
+        "1",
+        "1 pinch",
+        "40 g",
+        "80 g",
+        "1 stick",
       ]);
     });
   });


### PR DESCRIPTION
Will return an array of strings. These are the quantity that we need for the ingredients. It uses code based on of `findRecipeIngredients()`

The reason why `findRecipeIngredients()` and `findRecipeIngredientQuanity()` are separated is because it makes it easier to format the in two different columns in CSS. This also makes it easier to convert the quantities later.