### PR TITLE
Add function to get available tags plus recipe count associated with tag

### DIFF
--- a/src/recipes.js
+++ b/src/recipes.js
@@ -8,6 +8,16 @@ export const findRecipeIngredients = (recipe) => {
   }, []);
 };
 
+export function findRecipeIngredientsQuantity(recipe) {
+  return recipe.ingredients.map((ingredient) => {
+    const amount = ingredient.quantity.amount;
+    const unit = ingredient.quantity.unit;
+    const space = unit.length ? " " : "";
+
+    return `${amount}${space}${unit}`;
+  });
+}
+
 export const findRecipeInstructions = (recipe) => {
   return recipe.instructions
     .sort((a, b) => a.number - b.number)

--- a/src/tags.js
+++ b/src/tags.js
@@ -1,12 +1,22 @@
-import recipeData from '../src/data/recipes.js';
+import recipeData from "../src/data/recipes.js";
 
 export const filterRecipeByTag = (tags) => {
-    const filteredRecipes = [];
+  const filteredRecipes = [];
 
-    recipeData.forEach((recipe) => {
-        if (tags.every((tag) => recipe.tags.includes(tag))) {
-            filteredRecipes.push(recipe);
-        }
-    }); 
-    return filteredRecipes;
+  recipeData.forEach((recipe) => {
+    if (tags.every((tag) => recipe.tags.includes(tag))) {
+      filteredRecipes.push(recipe);
+    }
+  });
+  return filteredRecipes;
 };
+
+export function getAvailableTags(tags) {
+  return filterRecipeByTag(tags).reduce((list, recipe) => {
+    recipe.tags.forEach((tag) => {
+      if (!list.hasOwnProperty(tag)) list[tag] = 0;
+      list[tag]++;
+    });
+    return list;
+  }, {});
+}

--- a/test/recipes-test.js
+++ b/test/recipes-test.js
@@ -1,6 +1,10 @@
 import { expect } from "chai";
 import { recipe1, recipe2 } from "../src/data/mockRecipe";
-import { findRecipeIngredients, findRecipeInstructions } from "../src/recipes";
+import {
+  findRecipeIngredients,
+  findRecipeIngredientsQuantity,
+  findRecipeInstructions,
+} from "../src/recipes";
 
 describe("Recipe", () => {
   describe("Find ingredients", () => {
@@ -35,6 +39,38 @@ describe("Recipe", () => {
         "sesame seeds",
         "sucrose",
         "unsalted butter",
+      ]);
+    });
+  });
+
+  describe("Find quantity of ingredients", () => {
+    it("Should return an array of ingredients quantities given a recipe", () => {
+      const ingredients = findRecipeIngredientsQuantity(recipe1);
+      expect(ingredients).to.deep.equal([
+        "1.5 c",
+        "0.5 tsp",
+        "1 large",
+        "0.5 c",
+        "3 Tbsp",
+        "0.5 c",
+        "0.5 tsp",
+        "24 servings",
+        "2 c",
+        "0.5 c",
+        "0.5 tsp",
+      ]);
+    });
+
+    it("Should return a different array of ingredients quantities given a different recipe", () => {
+      const ingredients = findRecipeIngredientsQuantity(recipe2);
+      expect(ingredients).to.deep.equal([
+        "160 g",
+        "40 g",
+        "1",
+        "1 pinch",
+        "40 g",
+        "80 g",
+        "1 stick",
       ]);
     });
   });

--- a/test/tags-test.js
+++ b/test/tags-test.js
@@ -1,6 +1,7 @@
 import { expect } from "chai";
+import { recipe1, recipe2 } from "../src/data/mockRecipe";
 import recipeData from "../src/data/recipes";
-import { filterRecipeByTag } from "../src/tags";
+import { filterRecipeByTag, getAvailableTags } from "../src/tags";
 
 describe("filterRecipeByTag", function () {
   it("should find recipes by id tag", function () {
@@ -22,5 +23,51 @@ describe("filterRecipeByTag", function () {
 
     expect(recipesTag).to.be.an("array");
     expect(recipesTag).to.have.lengthOf(recipeData.length);
+  });
+});
+
+describe("Get available tags", () => {
+  it("Should return all tags in empty array", () => {
+    expect(getAvailableTags([])).to.deep.equal({
+      antipasti: 9,
+      starter: 9,
+      snack: 9,
+      appetizer: 9,
+      antipasto: 9,
+      "hor d'oeuvre": 9,
+      lunch: 12,
+      "main course": 12,
+      "main dish": 12,
+      dinner: 12,
+      sauce: 1,
+      "side dish": 22,
+      "morning meal": 1,
+      brunch: 1,
+      breakfast: 1,
+      salad: 4,
+      condiment: 1,
+      dip: 1,
+      spread: 1,
+    });
+  });
+
+  it("Should return the tags plus numbers given a set of tags #1", () => {
+    expect(getAvailableTags(["brunch"])).to.deep.equal({
+      breakfast: 1,
+      brunch: 1,
+      "morning meal": 1,
+    });
+  });
+
+  it("Should return the tags plus numbers given a set of tags #2", () => {
+    expect(getAvailableTags(["snack", "side dish"])).to.deep.equal({
+      antipasti: 1,
+      antipasto: 1,
+      appetizer: 1,
+      "hor d'oeuvre": 1,
+      "side dish": 1,
+      snack: 1,
+      starter: 1,
+    });
   });
 });

--- a/test/tags-test.js
+++ b/test/tags-test.js
@@ -1,16 +1,26 @@
-import { expect } from 'chai';
-import { filterRecipeByTag } from '../src/tags';
-describe('filterRecipeByTag', function() {
-    it('should find recipes by id tag', function() {
-        const recipesTag = filterRecipeByTag(['lunch']);
-        
-        expect(recipesTag).to.be.an('array');
-        expect(recipesTag).to.have.lengthOf(12);
-    });
-    it('should be able to find recipes with more than one id tag', function() {
-        const recipesWithMultipleTags = filterRecipeByTag(['snack', 'starter']); // Pass only the tag(s) as an array
-        
-        expect(recipesWithMultipleTags).to.be.an('array');
-        expect(recipesWithMultipleTags).to.have.lengthOf(9);       
-    });
+import { expect } from "chai";
+import recipeData from "../src/data/recipes";
+import { filterRecipeByTag } from "../src/tags";
+
+describe("filterRecipeByTag", function () {
+  it("should find recipes by id tag", function () {
+    const recipesTag = filterRecipeByTag(["lunch"]);
+
+    expect(recipesTag).to.be.an("array");
+    expect(recipesTag).to.have.lengthOf(12);
+  });
+
+  it("should be able to find recipes with more than one id tag", function () {
+    const recipesWithMultipleTags = filterRecipeByTag(["snack", "starter"]); // Pass only the tag(s) as an array
+
+    expect(recipesWithMultipleTags).to.be.an("array");
+    expect(recipesWithMultipleTags).to.have.lengthOf(9);
+  });
+
+  it("should return all recipes if using no tags", function () {
+    const recipesTag = filterRecipeByTag([]);
+
+    expect(recipesTag).to.be.an("array");
+    expect(recipesTag).to.have.lengthOf(recipeData.length);
+  });
 });


### PR DESCRIPTION
Adds a function that lets you pass an array of tags and return all possible future combinations of tags you can use with the number of recipes associated with each tag. This is a helper function used for the DOM.