### PR TITLE
refactor: Use recipe object instead of ID

### DIFF
--- a/src/recipes.js
+++ b/src/recipes.js
@@ -37,9 +37,9 @@ export function addRecipeToArray(recipesArray, recipeToAdd) {
   }
 }
 
-export function removeRecipeFromArray(recipesArray, recipeIdToRemove) {
+export function removeRecipeFromArray(recipesArray, recipeToRemove) {
   const recipeIndex = recipesArray.findIndex(
-    (recipe) => recipe.id === recipeIdToRemove
+    (recipe) => recipe.id === recipeToRemove.id
   );
   if (recipeIndex > -1) {
     recipesArray.splice(recipeIndex, 1);

--- a/test/recipes-test.js
+++ b/test/recipes-test.js
@@ -155,7 +155,7 @@ describe("Recipe", () => {
     });
 
     it("should be able to remove a recipe from an array", function () {
-      removeRecipeFromArray(recipesToCook, recipe1.id);
+      removeRecipeFromArray(recipesToCook, recipe1);
 
       expect(recipesToCook).to.not.include(recipe1);
       expect(recipesToCook).to.include(recipe2);


### PR DESCRIPTION
We remove a recipe from the array based on the recipe object instead of an ID.
This was done to keep things more consistent, because none of the other recipe functions use recipe ID.