### PR TITLE
feature: Add visual feedback

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -10,14 +10,19 @@
     <header>
       <h1 class="logo gatile">🍳 What's Cookin'</h1>
       <nav class="nav-buttons">
-        <button class="cookbook">COOKBOOK</button>
+        <button class="cookbook selected">COOKBOOK</button>
         <button class="saved-recipes">SAVED RECIPES</button>
       </nav>
     </header>
 
     <nav class="filter-container">
       <div class="filter-settings">
-        <input type="text" class="search-box" aria-label="search" placeholder="Search ..." />
+        <input
+          type="text"
+          class="search-box"
+          aria-label="search"
+          placeholder="Search ..."
+        />
         <h3>Tags</h3>
         <div class="tags-container"></div>
       </div>

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -81,6 +81,7 @@ main.addEventListener("click", (e) => {
         main.append(createRecipePageHTML(currentRecipe));
         main.setAttribute("id", "recipe-page");
         filterSection.classList.add("hidden");
+        // jank bug fix for recipe page
         body.style.cssText = "--sidebar-width: 0px";
       }
       break;
@@ -110,15 +111,21 @@ randomRecipeButton.addEventListener("click", () => {
   main.append(createRecipePageHTML(randomRecipe));
   main.setAttribute("id", "recipe-page");
   filterSection.classList.add("hidden");
+  // jank bug fix for recipe page
   body.style.cssText = "--sidebar-width: 0px";
 });
 
-navButtonContainer.addEventListener("click", (e) => {
+navButtonContainer.addEventListener("click", function (e) {
+  this.querySelectorAll("button").forEach((button) =>
+    button.classList.remove("selected")
+  );
+  e.target.classList.add("selected");
+
   if (e.target.classList.contains("cookbook")) {
-    isSavedRecipesView = false;
+    isSavedRecipesView = false; /* used for filtering */
     recipesToDisplay = recipesAPIData;
   } else if (e.target.classList.contains("saved-recipes")) {
-    isSavedRecipesView = true;
+    isSavedRecipesView = true; /* used for filtering */
     recipesToDisplay = currentUser.recipesToCook;
   } else {
     return;
@@ -126,6 +133,7 @@ navButtonContainer.addEventListener("click", (e) => {
 
   viewChanged = true;
   filterSection.classList.remove("hidden");
+  // jank bug fix for recipe page
   body.style.cssText = "--sidebar-width: 300px";
 
   mainDirectory.innerHTML = "";
@@ -206,7 +214,9 @@ function createRecipeHTML(recipe) {
     ? addRecipeToArray(currentUser.recipesToCook, recipe)
     : removeRecipeFromArray(currentUser.recipesToCook, recipe);
 
-  const recipeTags = (recipe.tags.length) ? `<h3 class="recipe-tags">${recipe.tags.join(", ")}</h3>` : ""
+  const recipeTags = recipe.tags.length
+    ? `<h3 class="recipe-tags">${recipe.tags.join(", ")}</h3>`
+    : "";
 
   article.innerHTML = `
     <div class="recipe-image">

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -58,6 +58,10 @@ header {
   .logo {
     font-size: 3rem;
   }
+
+  .selected {
+    text-decoration: underline;
+  }
 }
 
 nav.filter-container {


### PR DESCRIPTION
Added an underline bar under the current page selected. Previously the site did not have any indication on what page we were on and could be confusing.

The page by default will have a `selected` class on the cookbook page as that is the default page to load on. Then on each click, it will then clear any appearance of the `selected` class on all buttons before figuring out which button to add selected to.

This change may not be the most aesthetically pleasing but is clear and has clean code. 

Closes #42 