### PR TITLE
fixes tag/search filter bug

### DIFF
--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -371,20 +371,13 @@ function updateClearFilterButtons() {
 }
 
 function filterRecipes() {
-  viewChanged = true;
-  const recipe_dataset = isSavedRecipesView
-    ? currentUser.recipesToCook
-    : recipesAPIData;
-  let filteredRecipes = filterRecipeByTag(getActiveTags(), recipe_dataset);
+  const recipe_dataset = isSavedRecipesView ? currentUser.recipesToCook : recipesAPIData;
 
-  recipesToDisplay = search(
-    searchBox.value.trim(),
-    filteredRecipes,
-    ingredientsAPIData
-  );
+  let filteredByTags = filterRecipeByTag(getActiveTags(), recipe_dataset);
+
+  recipesToDisplay = search(searchBox.value.trim(), filteredByTags, ingredientsAPIData);
 
   displayRecipeCards(recipesToDisplay);
-  updateTags(recipesToDisplay);
   updateClearFilterButtons();
 }
 

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -248,6 +248,16 @@ function createRecipeHTML(recipe) {
   return article;
 }
 
+function createTagHTML(tagName, number) {
+  const tagNumber = number ? number : 0;
+
+  const button = document.createElement("button");
+  button.classList.add("tag");
+  button.dataset.tag = tagName;
+  button.textContent = `${tagName} (${tagNumber})`;
+  return button;
+}
+
 function createRecipePageHTML(recipe) {
   const recipeContainer = document.createElement("div");
   recipeContainer.classList.add("recipe-container");
@@ -342,14 +352,15 @@ function updateTags(recipes) {
   const tagNames = Object.keys(tagRecipeCount);
 
   tagsContainer.innerHTML = "";
+  activeTags.sort().forEach((tagName) => {
+    const tag = createTagHTML(tagName, tagRecipeCount[tagName]);
+    tag.classList.add("tag-active");
+    tagsContainer.appendChild(tag);
+  });
   tagNames.forEach((tagName) => {
-    const button = document.createElement("button");
-    button.className = "tag";
-    button.dataset.tag = tagName;
-    button.textContent = `${tagName} (${tagRecipeCount[tagName]})`;
-
-    if (activeTags.includes(tagName)) button.classList.add("tag-active");
-    tagsContainer.appendChild(button);
+    if (activeTags.find((activeTag) => activeTag === tagName)) return;
+    const tag = createTagHTML(tagName, tagRecipeCount[tagName]);
+    tagsContainer.appendChild(tag);
   });
 }
 
@@ -370,15 +381,20 @@ function updateClearFilterButtons() {
     : clearTagsButton.classList.add("hidden");
 }
 
-function filterRecipes() {
-  const recipe_dataset = isSavedRecipesView ? currentUser.recipesToCook : recipesAPIData;
+const filterRecipes = () => {
+  const recipes = isSavedRecipesView
+    ? currentUser.recipesToCook
+    : recipesAPIData;
 
-  let filteredByTags = filterRecipeByTag(getActiveTags(), recipe_dataset);
-
-  recipesToDisplay = search(searchBox.value.trim(), filteredByTags, ingredientsAPIData);
+  recipesToDisplay = search(
+    searchBox.value.trim(),
+    filterRecipeByTag(getActiveTags(), recipes),
+    ingredientsAPIData
+  );
 
   displayRecipeCards(recipesToDisplay);
+  updateTags(recipesToDisplay);
   updateClearFilterButtons();
-}
+};
 
 export { displayRecipeCards as displayRecipes };


### PR DESCRIPTION
I adjusted the filterRecipes function. Now the search bar properly responds to the selected tags and only finds recipes that match both the selected tags and current search bar input. If tags removed, search input remains and vice versa.

Currently, the tags don't dynamically change based on the search bar input, but that was intentional by me, since I found it's easier to keep track of as user. Open to the alternative though.

Closes #39 