### PR TITLE
refactor: Make search test more specific

### DIFF
--- a/test/search-test.js
+++ b/test/search-test.js
@@ -1,7 +1,14 @@
 import { expect } from "chai";
 import { findRecipeIngredients } from "../src/recipes";
 import { search } from "../src/search";
-import { mockIngredients, mockRecipeDataset } from "./data/mockData";
+import {
+  mockIngredients,
+  mockRecipeDataset,
+  recipe1,
+  recipe2,
+  recipe3,
+  recipe4,
+} from "./data/mockData";
 
 describe("Search", () => {
   it("Will return an array", () => {
@@ -9,54 +16,24 @@ describe("Search", () => {
     expect(Array.isArray(searchResult)).to.equal(true);
   });
 
-  it("Will return some recipes that have matching ingredients or name 'co' (known to exist in database)", () => {
-    const searchQuery = "co";
+  it("Will return some recipes that have matching ingredients or name 'su' (known to exist in database)", () => {
+    const searchQuery = "sug";
     const searchResult = search(
       searchQuery,
       mockRecipeDataset,
       mockIngredients
     );
-    const sanitizedQuery = searchQuery.toLowerCase();
-
-    let searchPassCount = 0;
-    for (const result of searchResult) {
-      if (
-        result.name.toLowerCase().includes(sanitizedQuery) ||
-        findRecipeIngredients(result, mockIngredients).find((ingredient) =>
-          ingredient.toLowerCase().includes(sanitizedQuery)
-        )
-      ) {
-        searchPassCount++;
-      }
-    }
-
-    expect(searchResult.length).to.not.equal(0);
-    expect(searchPassCount).to.equal(searchResult.length);
+    expect(searchResult).to.deep.equal([recipe1, recipe3]);
   });
 
-  it("Will return some recipes that have matching ingredients or name 'wing' (known to exist in database)", () => {
-    const searchQuery = "wing";
+  it("Will return some recipes that have matching ingredients or name 'cookie' (known to exist in database)", () => {
+    const searchQuery = "cookie";
     const searchResult = search(
       searchQuery,
       mockRecipeDataset,
       mockIngredients
     );
-    const sanitizedQuery = searchQuery.toLowerCase();
-
-    let searchPassCount = 0;
-    for (const result of searchResult) {
-      if (
-        result.name.toLowerCase().includes(sanitizedQuery) ||
-        findRecipeIngredients(result, mockIngredients).find((ingredient) =>
-          ingredient.toLowerCase().includes(sanitizedQuery)
-        )
-      ) {
-        searchPassCount++;
-      }
-    }
-
-    expect(searchResult.length).to.not.equal(0);
-    expect(searchPassCount).to.equal(searchResult.length);
+    expect(searchResult).to.deep.equal([recipe1, recipe2]);
   });
 
   it("Will return an empty array 'space monkeys' (does not exist)", () => {
@@ -66,6 +43,6 @@ describe("Search", () => {
       mockRecipeDataset,
       mockIngredients
     );
-    expect(searchResult.length).to.equal(0);
+    expect(searchResult).to.deep.equal([]);
   });
 });


### PR DESCRIPTION
Now the search will specific test to make sure the results are the exact same instead of checking if the length is the same.
Closes #38