### PR TITLE
Unselect nav button on recipe page change + refactoring

### DIFF
--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -78,24 +78,17 @@ main.addEventListener("click", (e) => {
   switch (main.getAttribute("id")) {
     case "directory-page":
       if (!e.target.closest(".recipe-card")) return;
-
       const clickedRecipe = e.target.closest(".recipe-card");
       const recipe = findRecipeFromID(clickedRecipe.dataset.id, recipesAPIData);
-      setCurrentRecipe(recipe);
 
       if (e.target.closest(".heart-container")) {
         toggleHeart(
           e.target.closest(".heart-container"),
-          currentRecipe,
+          recipe,
           currentUser.recipesToCook
         );
       } else {
-        main.innerHTML = "";
-        main.append(createRecipePageHTML(currentRecipe));
-        main.setAttribute("id", "recipe-page");
-        filterSection.classList.add("hidden");
-        // jank bug fix for recipe page
-        body.style.cssText = "--sidebar-width: 0px";
+        setPageToRecipe(recipe);
       }
       break;
     case "recipe-page":
@@ -119,14 +112,7 @@ main.addEventListener("click", (e) => {
 randomRecipeButton.addEventListener("click", () => {
   const randomIndex = randomNumber(recipesAPIData.length);
   const randomRecipe = recipesAPIData[randomIndex];
-  setCurrentRecipe(randomRecipe);
-
-  main.innerHTML = "";
-  main.append(createRecipePageHTML(randomRecipe));
-  main.setAttribute("id", "recipe-page");
-  filterSection.classList.add("hidden");
-  // jank bug fix for recipe page
-  body.style.cssText = "--sidebar-width: 0px";
+  setPageToRecipe(randomRecipe);
 });
 
 navButtonContainer.addEventListener("click", function (e) {
@@ -337,6 +323,17 @@ function toggleHeart(element, recipe, recipe_dataset) {
     element.innerHTML = heartOff;
     removeRecipeFromArray(recipe_dataset, recipe);
   }
+}
+
+function setPageToRecipe(recipe) {
+  setCurrentRecipe(recipe);
+
+  main.innerHTML = "";
+  main.append(createRecipePageHTML(recipe));
+  main.setAttribute("id", "recipe-page");
+  filterSection.classList.add("hidden");
+  // jank bug fix for recipe page
+  body.style.cssText = "--sidebar-width: 0px";
 }
 
 function getActiveTags() {

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -326,6 +326,10 @@ function toggleHeart(element, recipe, recipe_dataset) {
 }
 
 function setPageToRecipe(recipe) {
+  navButtonContainer
+    .querySelectorAll("button")
+    .forEach((button) => button.classList.remove("selected"));
+
   setCurrentRecipe(recipe);
 
   main.innerHTML = "";

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,4 +1,6 @@
-$sidebar-width: 300px;
+:root {
+  --sidebar-width: 300px;
+}
 
 .hidden {
   visibility: hidden !important;
@@ -22,7 +24,7 @@ html {
 
 body {
   display: grid;
-  grid-template-columns: $sidebar-width 1fr;
+  grid-template-columns: var(--sidebar-width) 1fr;
   grid-template-rows: 100px 1fr;
   gap: 10px;
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -53,6 +53,10 @@ header {
     height: 50px;
     width: 200px;
     font-size: 20px;
+
+    &:hover {
+      text-decoration: underline;
+    }
   }
 
   .logo {


### PR DESCRIPTION
I moved the code for switching a page to an individual recipe page into a function so that way we don't repeat ourselves and constantly have to remember to update all instances where we want to switch to a recipe page. This issue can be seen when we forgot to `setCurrentRecipe` in issue #47 

In this function, we always remove any selected button, so that way it is clear whether we are in cookbook, recipe pages, or neither.