### PR TITLE
Display multiple warning messages + refactoring

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -36,7 +36,9 @@
     <main id="directory-page">
       <div class="sentinel"></div>
     </main>
-    <div class="warning" style="display: none;">Warning message here</div>
+
+    <div class="warning-container">
+    </div>
   </body>
   <!-- Do not include the scripts.js file here - it is done automatically by the webpack server -->
   <script src="bundle.js"></script>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "webpack serve",
     "build": "webpack",
-    "test": "mochapack 'test/**/*.js'"
+    "test": "mochapack 'test/**/*.js'",
+    "pages": "git subtree push --prefix dist origin gh-pages"
   },
   "author": "Turing School of Software and Design",
   "license": "MIT",
@@ -24,6 +25,7 @@
     "webpack-dev-server": "^3.11.2"
   },
   "dependencies": {
+    "boxicons": "^2.1.4",
     "convert-units": "^2.3.4"
   }
 }

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -4,7 +4,7 @@
 // global.recipesAPIData = recipesAPIData;
 // global.ingredientsAPIData = ingredientsAPIData;
 
-import { displayWarning } from '../src/domUpdates.js';
+import { displayWarning } from "../src/domUpdates.js";
 
 export let usersAPIData;
 export let recipesAPIData;
@@ -16,7 +16,7 @@ function fetchData(name) {
     .then((data) => data[name])
     .catch((error) => {
       console.error(error);
-      displayWarning('Unable to fetch data. Please try again later.');
+      displayWarning("Unable to fetch data. Please try again later.");
     });
 }
 

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -16,7 +16,7 @@ function fetchData(name) {
     .then((data) => data[name])
     .catch((error) => {
       console.error(error);
-      displayWarning("Unable to fetch data. Please try again later.");
+      displayWarning(`Unable to fetch ${name} data. Please try again later.`);
     });
 }
 

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -398,16 +398,20 @@ const filterRecipes = () => {
   updateClearFilterButtons();
 };
 
-const displayWarning = (message) => {
-  const warningMessageElement = document.querySelector(".warning");
-  if (!warningMessageElement) return;
+const displayWarning = (message, iconName = "bug-alt", timeout = 3000) => {
+  const warningMessageContainer = document.querySelector(".warning-container");
+  if (!warningMessageContainer) return;
 
-  warningMessageElement.textContent = message;
-  warningMessageElement.style.display = "block";
+  const warning = document.createElement("div");
+  warning.classList.add("warning");
+  warning.innerHTML = `
+  <box-icon color='white' name='${iconName}'></box-icon>
+  ${message}`;
+  warningMessageContainer.appendChild(warning);
 
   setTimeout(() => {
-    warningMessageElement.style.display = "none";
-  }, 3000);
+    warningMessageContainer.querySelector(".warning").remove();
+  }, timeout);
 };
 
 export { displayRecipeCards as displayRecipes, displayWarning };

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -49,10 +49,6 @@ const filterSettings = document.querySelector(".filter-settings");
 const clearSearchButton = document.querySelector(".clear-search");
 const clearTagsButton = document.querySelector(".clear-tags");
 
-const heartOn =
-  '<svg class="heart" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style="fill: #b30202;transform: ;msFilter:;"><path d="M20.205 4.791a5.938 5.938 0 0 0-4.209-1.754A5.906 5.906 0 0 0 12 4.595a5.904 5.904 0 0 0-3.996-1.558 5.942 5.942 0 0 0-4.213 1.758c-2.353 2.363-2.352 6.059.002 8.412L12 21.414l8.207-8.207c2.354-2.353 2.355-6.049-.002-8.416z"></path></svg>';
-const heartOff = `<svg class="heart" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" style=" fill: rgba(157, 150, 139, 1); transform: scaleX(-1); msFilter: 'progid:DXImageTransform.Microsoft.BasicImage(rotation=0, mirror=1)';"> <path d="M12 4.595a5.904 5.904 0 0 0-3.996-1.558 5.942 5.942 0 0 0-4.213 1.758c-2.353 2.363-2.352 6.059.002 8.412l7.332 7.332c.17.299.498.492.875.492a.99.99 0 0 0 .792-.409l7.415-7.415c2.354-2.354 2.354-6.049-.002-8.416a5.938 5.938 0 0 0-4.209-1.754A5.906 5.906 0 0 0 12 4.595zm6.791 1.61c1.563 1.571 1.564 4.025.002 5.588L12 18.586l-6.793-6.793c-1.562-1.563-1.561-4.017-.002-5.584.76-.756 1.754-1.172 2.799-1.172s2.035.416 2.789 1.17l.5.5a.999.999 0 0 0 1.414 0l.5-.5c1.512-1.509 4.074-1.505 5.584-.002z"></path></svg>`;
-
 // EVENT LISTENERS
 addEventListener("load", function () {
   fetchServerData().then(() => init());
@@ -207,8 +203,8 @@ function createRecipeHTML(recipe) {
   article.dataset.id = recipe.id;
 
   const heartIcon = isRecipeFavorited(recipe, currentUser.recipesToCook)
-    ? heartOn
-    : heartOff;
+    ? "<box-icon size='md' name='heart' type='solid' color='red'></box-icon>"
+    : "<box-icon size='md' name='heart' ></box-icon>";
 
   isRecipeFavorited(recipe, currentUser.recipesToCook)
     ? addRecipeToArray(currentUser.recipesToCook, recipe)
@@ -261,8 +257,8 @@ function createRecipePageHTML(recipe) {
   );
 
   const heartIcon = isRecipeFavorited(recipe, currentUser.recipesToCook)
-    ? heartOn
-    : heartOff;
+    ? "<box-icon size='md' name='heart' type='solid' color='red'></box-icon>"
+    : "<box-icon size='md' name='heart' ></box-icon>";
 
   const checkboxChecked = convertToUS ? "" : "checked";
 
@@ -317,10 +313,11 @@ function getIngredientQuantity(recipe, ingredientDataset) {
 function toggleHeart(element, recipe, recipeDataset) {
   const isFavorited = isRecipeFavorited(recipe, recipeDataset);
   if (!isFavorited) {
-    element.innerHTML = heartOn;
+    element.innerHTML =
+      "<box-icon size='md' name='heart' type='solid' color='red'></box-icon>";
     addRecipeToArray(recipeDataset, recipe);
   } else {
-    element.innerHTML = heartOff;
+    element.innerHTML = "<box-icon size='md' name='heart'></box-icon>";
     removeRecipeFromArray(recipeDataset, recipe);
   }
 }
@@ -402,18 +399,15 @@ const filterRecipes = () => {
 };
 
 const displayWarning = (message) => {
-  const warningMessageElement = document.querySelector('.warning');
+  const warningMessageElement = document.querySelector(".warning");
   if (!warningMessageElement) return;
 
   warningMessageElement.textContent = message;
-  warningMessageElement.style.display = 'block';
+  warningMessageElement.style.display = "block";
 
   setTimeout(() => {
-    warningMessageElement.style.display = 'none';
+    warningMessageElement.style.display = "none";
   }, 3000);
 };
 
-export { 
-  displayRecipeCards as displayRecipes,
-  displayWarning
-};
+export { displayRecipeCards as displayRecipes, displayWarning };

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -398,7 +398,7 @@ const filterRecipes = () => {
   updateClearFilterButtons();
 };
 
-const displayWarning = (message, iconName = "bug-alt", timeout = 3000) => {
+const displayWarning = (message, iconName = "bug-alt") => {
   const warningMessageContainer = document.querySelector(".warning-container");
   if (!warningMessageContainer) return;
 
@@ -411,7 +411,7 @@ const displayWarning = (message, iconName = "bug-alt", timeout = 3000) => {
 
   setTimeout(() => {
     warningMessageContainer.querySelector(".warning").remove();
-  }, timeout);
+  }, 3000);
 };
 
 export { displayRecipeCards as displayRecipes, displayWarning };

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -3,6 +3,7 @@
 import "./domUpdates";
 import "./styles.scss";
 // An example of how you tell webpack to use an image (also need to link to it in the index.html)
+import "boxicons";
 import "./images/turing-logo.png";
 // Below are examples of how you can import functions from either the recipes or domUpdates files.
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -204,11 +204,6 @@ main#directory-page {
     justify-content: space-between;
   }
 
-  .heart {
-    height: 35px;
-    width: 35px;
-  }
-
   .recipe-image {
     object-fit: cover;
     overflow: hidden;
@@ -255,11 +250,6 @@ main#recipe-page {
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
-  }
-
-  .heart-container {
-    height: 30px;
-    width: 30px;
   }
 
   .recipe-main {
@@ -404,7 +394,7 @@ input:checked + .slider:before {
   border-radius: 50%;
 }
 
-// Error message 
+// Error message
 .warning {
   padding: 1.25rem;
   background-color: #f44336;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -395,14 +395,30 @@ input:checked + .slider:before {
 }
 
 // Error message
-.warning {
-  padding: 1.25rem;
-  background-color: #f44336;
-  color: white;
+.warning-container {
+  box-icon {
+    margin-right: 10px;
+  }
+  .warning {
+    background-color: #f44336;
+    color: white;
+
+    width: fit-content;
+    padding: 1.25rem;
+    border-radius: 5px;
+
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+
+    display: flex;
+    align-items: center;
+  }
+
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 10px;
+
   position: absolute;
   bottom: 1.25rem;
   left: 1.25rem;
   z-index: 1000;
-  border-radius: 5px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }


### PR DESCRIPTION
## Display Multiple Warning PR

The way I implemented multiple warnings was by creating an empty div container that we could add warnings into. That way we don't need to unhide or hide warnings anymore. The `setTimeout` will query the oldest warning and remove it from the page. This will automatically create the effect of keeping each warning every 3 seconds.

I also added the ability to chose which box-icon you want to add to the warning. Perhaps in the future we expand this function to also let you chose the color of the warning. I wanted to implement this feature but ran into issues with the parameters being very long. Maybe we use an object that we pass in?

This closes #56 

### Misc Changes
- I added the box-icons npm package into our code. We can now add box-icons anywhere we want an svg icon throughout the site. Now we don't need to have `heartOn` or `heartOff` as variables storing the SVG code. They have been replaced with the box-icon counterpart. To use the package follow the instructions here: [boxicon useage guide](https://boxicons.com/usage)
- I refactored the warning in `apiCalls.js` to return the name of the data you were trying to get so it was more clear which part failed.
- I added a script to auto deploy our dist folder to github pages.