### PR TITLE
Adds back & foward browser functionality using History API

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -8,7 +8,9 @@
   </head>
   <body>
     <header>
-      <h1 class="logo gatile">🍳 What's Cookin'</h1>
+      <h1 class="logo gatile">
+        🍳 What's Cookin' <span class="user-name"></span>?
+      </h1>
       <nav class="nav-buttons">
         <button class="cookbook selected">COOKBOOK</button>
         <button class="saved-recipes">SAVED RECIPES</button>
@@ -17,12 +19,12 @@
 
     <nav class="filter-container">
       <div class="filter-settings">
-          <input
-            type="text"
-            class="search-box"
-            aria-label="search"
-            placeholder="Search ..."
-          />
+        <input
+          type="text"
+          class="search-box"
+          aria-label="search"
+          placeholder="Search ..."
+        />
         <button class="clear-search hidden">X</button>
         <div class="tags-header">
           <h2>Tags</h2>
@@ -37,8 +39,7 @@
       <div class="sentinel"></div>
     </main>
 
-    <div class="warning-container">
-    </div>
+    <div class="warning-container"></div>
   </body>
   <!-- Do not include the scripts.js file here - it is done automatically by the webpack server -->
   <script src="bundle.js"></script>

--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -26,17 +26,19 @@ export function fetchServerData() {
     fetchData("users"),
     fetchData("ingredients"),
     fetchData("recipes"),
-  ]).then(([users, ingredients, recipes]) => {
-    usersAPIData = users;
-    ingredientsAPIData = ingredients;
-    recipesAPIData = recipes;
-  }).then(() => {
-    usersAPIData.forEach(user => {
-      user.recipesToCook = user.recipesToCook.map(id => {
-        return findRecipeFromID(id, recipesAPIData)
-      })
+  ])
+    .then(([users, ingredients, recipes]) => {
+      usersAPIData = users;
+      ingredientsAPIData = ingredients;
+      recipesAPIData = recipes;
+    })
+    .then(() => {
+      usersAPIData.forEach((user) => {
+        user.recipesToCook = user.recipesToCook.map((id) => {
+          return findRecipeFromID(id, recipesAPIData);
+        });
+      });
     });
-  })
 }
 
 export function sendServerData(userID, recipeID) {
@@ -46,7 +48,7 @@ export function sendServerData(userID, recipeID) {
     body: JSON.stringify({ userID, recipeID }),
   })
     .then((response) => {
-      if (!response.ok) throw new Error(`Error: ${response.status}`);
+      if (!response.ok) throw new Error(`${response.status}`);
       else return response.json();
     })
     .then((data) => {

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -177,7 +177,7 @@ function init() {
 
 const infiniteLoad = (function () {
   let currentPage = 0;
-  const recipesPerPage = 5;
+  const recipesPerPage = 8;
 
   function resetView() {
     viewChanged = false;

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -374,13 +374,12 @@ function setPageToDirectory() {
 
   viewChanged = true;
   filterSection.classList.remove("hidden");
-  // jank bug fix for recipe page
-  body.style.cssText = "--sidebar-width: 300px";
-
   mainDirectory.innerHTML = "";
   main.setAttribute("id", "directory-page");
   displayRecipeCards(recipesToDisplay);
   resetFilters(recipesToDisplay);
+  // jank bug fix for recipe page
+  body.style.cssText = "--sidebar-width: 300px";
 }
 
 function setPageToRecipe(recipe) {

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -224,9 +224,7 @@ function createRecipeHTML(recipe) {
     ? addRecipeToArray(currentUser.recipesToCook, recipe)
     : removeRecipeFromArray(currentUser.recipesToCook, recipe);
 
-  const recipeTags = recipe.tags.length
-    ? `<h3 class="recipe-tags">${recipe.tags.join(", ")}</h3>`
-    : "";
+  const recipeTags = recipe.tags.length ? recipe.tags.join(", ") : "no-tags";
 
   article.innerHTML = `
     <div class="recipe-image">
@@ -235,7 +233,7 @@ function createRecipeHTML(recipe) {
     </div>
     <div class="recipe-info">
       <div class="tags-and-heart">
-        ${recipeTags}
+        <h3 class="recipe-tags">${recipeTags}</h3>
         <div class="heart-container">${heartIcon}</div>
       </div>
       <h2 class="recipe-name">${recipe.name}</h2>

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -181,6 +181,7 @@ const infiniteLoad = (function () {
 
   function resetView() {
     viewChanged = false;
+    mainDirectory.innerHTML = "";
     mainDirectory.scrollTop = 0;
     currentPage = 0;
   }
@@ -443,6 +444,8 @@ function updateClearFilterButtons() {
 }
 
 const filterRecipes = (recipes) => {
+  viewChanged = true;
+
   recipesToDisplay = search(
     searchBox.value.trim(),
     filterRecipeByTag(getActiveTags(), recipes),

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -57,17 +57,17 @@ global.addEventListener("load", function () {
   fetchServerData().then(() => init());
 });
 global.addEventListener("popstate", (e) => {
-  if (e.state) {
-    const state = e.state;
-    switch (state.page) {
-      case "directory":
-        isSavedRecipesView = state.isSavedRecipesView;
-        setPageToDirectory();
-        break;
-      case "recipe":
-        setPageToRecipe(findRecipeFromID(state.id, recipesAPIData));
-        break;
-    }
+  if (!e.state) return;
+  const state = e.state;
+
+  switch (state.page) {
+    case "directory":
+      isSavedRecipesView = state.isSavedRecipesView;
+      setPageToDirectory();
+      break;
+    case "recipe":
+      setPageToRecipe(findRecipeFromID(state.id, recipesAPIData));
+      break;
   }
 });
 searchBox.addEventListener("input", function () {

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -338,7 +338,8 @@ function toggleHeart(element, recipe, recipeDataset) {
     addRecipeToArray(recipeDataset, recipe);
     sendServerData(currentUser.id, recipe.id);
   } else {
-    element.innerHTML = "<box-icon class='heart' animation='tada-hover' size='md' name='heart'></box-icon>";
+    element.innerHTML =
+      "<box-icon class='heart' animation='tada-hover' size='md' name='heart'></box-icon>";
     removeRecipeFromArray(recipeDataset, recipe);
   }
 }
@@ -449,13 +450,19 @@ function printRecipe(recipe, ingredientDataset) {
     .join("");
 
   const printWindow = window.open("", "_blank", "height=600,width=800");
-  printWindow.document.write("<html><head><title>Print</title></head><body>");
-  printWindow.document.write(`<h1>${recipe.name}</h1>`);
-  printWindow.document.write(`<h2>Ingredients</h2><ul>${ingredientList}</ul>`);
-
-  printWindow.document.write(`<h2>Instructions</h2>
-  <ol>${instructionsList}</ol>`);
-  printWindow.document.write("</body></html>");
+  printWindow.document.write(`
+  <html>
+    <head>
+      <title>Print</title>
+    </head>
+    <body>
+      <h1>${recipe.name}</h1>
+      <h2>Ingredients</h2>
+      <ul>${ingredientList}</ul>
+      <h2>Instructions</h2>
+      <ol>${instructionsList}</ol>
+    </body>
+  </html>`);
 
   printWindow.document.close(); // necessary for IE >= 10
   printWindow.focus(); // necessary for IE >= 10*/

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -149,10 +149,8 @@ randomRecipeButton.addEventListener("click", () => {
 navButtonContainer.addEventListener("click", function (e) {
   if (e.target.classList.contains("cookbook")) {
     isSavedRecipesView = false; /* used for filtering */
-    recipesToDisplay = recipesAPIData;
   } else if (e.target.classList.contains("saved-recipes")) {
     isSavedRecipesView = true; /* used for filtering */
-    recipesToDisplay = currentUser.recipesToCook;
   } else {
     return;
   }

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -49,14 +49,6 @@ const randomRecipeButton = document.querySelector(".random-recipe");
 const filterSettings = document.querySelector(".filter-settings");
 const clearSearchButton = document.querySelector(".clear-search");
 const clearTagsButton = document.querySelector(".clear-tags");
-// Iteration 6
-document.addEventListener("DOMContentLoaded", function () {
-  main.addEventListener("click", function (event) {
-    if (event.target.classList.contains("print-button")) {
-      printRecipe();
-    }
-  });
-});
 
 // EVENT LISTENERS
 addEventListener("load", function () {

--- a/src/domUpdates.js
+++ b/src/domUpdates.js
@@ -129,15 +129,7 @@ navButtonContainer.addEventListener("click", function (e) {
     return;
   }
 
-  viewChanged = true;
-  filterSection.classList.remove("hidden");
-  // jank bug fix for recipe page
-  body.style.cssText = "--sidebar-width: 300px";
-
-  mainDirectory.innerHTML = "";
-  main.setAttribute("id", "directory-page");
-  displayRecipeCards(recipesToDisplay);
-  resetFilters(recipesToDisplay);
+  setPageToDirectory();
 });
 
 // FUNCTIONS
@@ -332,6 +324,18 @@ function toggleHeart(element, recipe, recipeDataset) {
       "<box-icon class='heart' animation='tada-hover' size='md' name='heart'></box-icon>";
     removeRecipeFromArray(recipeDataset, recipe);
   }
+}
+
+function setPageToDirectory() {
+  viewChanged = true;
+  filterSection.classList.remove("hidden");
+  // jank bug fix for recipe page
+  body.style.cssText = "--sidebar-width: 300px";
+
+  mainDirectory.innerHTML = "";
+  main.setAttribute("id", "directory-page");
+  displayRecipeCards(recipesToDisplay);
+  resetFilters(recipesToDisplay);
 }
 
 function setPageToRecipe(recipe) {

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -21,6 +21,9 @@ export function randomNumber(max) {
 
 export function setCurrentUser(user) {
   currentUser = user;
+  // update name here cause this is only time you'll update name
+  const usernameNode = document.querySelector(".user-name");
+  usernameNode.innerText = user.name;
 }
 
 export function setCurrentRecipe(recipe) {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -160,7 +160,8 @@ nav.filter-container {
   }
 }
 
-.heart {
+.heart,
+.print-icon {
   cursor: pointer;
 }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -116,6 +116,10 @@ nav.filter-container {
     display: flex;
     justify-content: space-between;
     align-items: center;
+
+    h2 {
+      margin: 0;
+    }
   }
 
   .clear-tags {
@@ -230,7 +234,7 @@ main#directory-page {
     top: 10px;
     left: 10px;
     z-index: 2;
-    background-color: rgba(255, 255, 255, 0.5); 
+    background-color: rgba(255, 255, 255, 0.5);
     border-radius: 5px;
   }
 }
@@ -308,7 +312,7 @@ main#recipe-page {
     }
 
     .print-button {
-      background-color: #8B0000;
+      background-color: #8b0000;
       color: white;
       border-radius: 4px;
       border: none;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -311,14 +311,6 @@ main#recipe-page {
       text-align: center;
     }
 
-    .print-button {
-      background-color: #8b0000;
-      color: white;
-      border-radius: 4px;
-      border: none;
-      padding: 0.5rem;
-    }
-
     li {
       padding-left: 25px;
       margin-top: 20px;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -242,7 +242,7 @@ main#directory-page {
 
 .sentinel {
   position: relative;
-  height: 1px;
+  height: 0px;
 }
 
 .tag-active {


### PR DESCRIPTION
Because the site is a SPA (single page application), we could not use the browser's front and back buttons. There was no way of navigating forward or backwards in history.

Using the History API, the page now has proper back and forward functionality. We are able to set the state of the application during each view change and record them. Using this state, we can reinit the page state when we use back and forward.  To see how to use the History API I followed [this guide](https://developer.mozilla.org/en-US/docs/Web/API/History_API/Working_with_the_History_API)

This PR also includes refactor changes that helped History API, or cleaned up code. There were also misc bug fixes that made their way into main that have been removed.

Closes #67